### PR TITLE
Add conversation generation using DialoGPT

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,21 @@ repo for robotics project that serves coffee to people in need of caffeination u
    ```
 
 3. The script will output the coordinates of detected people in the image.
+
+## Conversation Generation using DialoGPT
+
+### Setup DialoGPT
+
+1. Install the necessary dependencies:
+   ```bash
+   pip install transformers torch
+   ```
+
+### Using the `conversation_generation.py` script
+
+1. Run the `conversation_generation.py` script:
+   ```bash
+   python conversation_generation.py
+   ```
+
+2. The script will prompt you to enter a message, and it will generate a response using the DialoGPT model.

--- a/conversation_generation.py
+++ b/conversation_generation.py
@@ -1,0 +1,29 @@
+import torch
+from transformers import AutoModelForCausalLM, AutoTokenizer
+
+# Load pre-trained DialoGPT model
+tokenizer = AutoTokenizer.from_pretrained("microsoft/DialoGPT-medium")
+model = AutoModelForCausalLM.from_pretrained("microsoft/DialoGPT-medium")
+
+def generate_response(input_text):
+    # Encode the input text
+    input_ids = tokenizer.encode(input_text + tokenizer.eos_token, return_tensors="pt")
+
+    # Generate response using the model
+    response_ids = model.generate(input_ids, max_length=1000, pad_token_id=tokenizer.eos_token_id)
+
+    # Decode the response
+    response_text = tokenizer.decode(response_ids[:, input_ids.shape[-1]:][0], skip_special_tokens=True)
+
+    return response_text
+
+def main():
+    while True:
+        input_text = input("You: ")
+        if input_text.lower() in ["exit", "quit"]:
+            break
+        response_text = generate_response(input_text)
+        print(f"Bot: {response_text}")
+
+if __name__ == "__main__":
+    main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,2 @@
+transformers
+torch


### PR DESCRIPTION
Related to #3

Add conversation generation functionality using DialoGPT.

* **New Files**
  - Add `requirements.txt` with `transformers` and `torch` libraries.
  - Add `conversation_generation.py` script to load pre-trained DialoGPT model, generate responses, and test conversation generation.

* **README.md**
  - Add instructions to install dependencies for conversation generation.
  - Add usage instructions for `conversation_generation.py` script.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Bendemeurichy/robotics_brewbuddy/issues/3?shareId=ebd71320-4649-4bf0-a078-eb41bd34f0bb).